### PR TITLE
Generics

### DIFF
--- a/NLambda.cabal
+++ b/NLambda.cabal
@@ -18,7 +18,6 @@ Library
     bytestring,
     combinat,
     containers,
-    deepseq,
     directory,
     MissingH,
     mtl,

--- a/src/NLambda.hs
+++ b/src/NLambda.hs
@@ -39,7 +39,7 @@ import Nominal.Set as Export
 #else
 import Nominal.Set as Export hiding (range, openRange, isLowerBound, hasLowerBound, isUpperBound, hasUpperBound, isMinimum, hasMinimum, isMaximum, hasMaximum, isInfimum, isSupremum, isConnected, isOpen, isClosed, isCompact)
 #endif
-import Nominal.Type as Export (BareNominalType(..), NominalType(..), Scope, MapVarFun, FoldVarFun, neq)
+import Nominal.Type as Export (NominalType(..), Scope, MapVarFun, FoldVarFun, neq)
 import Nominal.Variable as Export (Variable, variable)
 import Nominal.Variants as Export (Variants, variant, fromVariant, iteV)
 import Prelude hiding (or, and, not, sum, map, filter, maybe)

--- a/src/Nominal/Atoms/Signature.hs
+++ b/src/Nominal/Atoms/Signature.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP, MultiParamTypeClasses #-}
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Nominal.Atoms.Signature where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import Nominal.Text.Symbols
 import Text.ParserCombinators.ReadP (choice, string)
 import Text.Read (ReadPrec, (<++), lift, parens, readPrec, step)
@@ -20,7 +17,7 @@ import Text.Read.Lex (Lexeme(Symbol))
 ----------------------------------------------------------------------------------------------------
 -- Relation
 ----------------------------------------------------------------------------------------------------
-data Relation = LessThan | LessEquals | Equals | NotEquals | GreaterEquals | GreaterThan deriving (Eq, Ord, Enum, Generic, NFData)
+data Relation = LessThan | LessEquals | Equals | NotEquals | GreaterEquals | GreaterThan deriving (Eq, Ord, Enum)
 
 relations :: [Relation]
 relations = [LessThan ..]

--- a/src/Nominal/Automaton/Base.hs
+++ b/src/Nominal/Automaton/Base.hs
@@ -19,7 +19,7 @@ import GHC.Generics (Generic)
 -- | An automaton with a set of state with type __q__ accepting\/rejecting words from an alphabet with type __a__.
 data Automaton q a = Automaton {states :: Set q, alphabet :: Set a, delta :: Set (q, a, q),
                                 initialStates :: Set q, finalStates :: Set q}
-  deriving (Eq, Ord, Show, Read, Generic, BareNominalType, Contextual, Conditional)
+  deriving (Eq, Ord, Show, Read, Generic, NominalType, Contextual, Conditional)
 
 -- | An automaton constructor.
 automaton :: (NominalType q, NominalType a) => Set q -> Set a -> Set (q, a, q) -> Set q -> Set q -> Automaton q a

--- a/src/Nominal/Conditional.hs
+++ b/src/Nominal/Conditional.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Nominal.Conditional (Conditional(cond), ite) where
 
 import Nominal.Formula
 import Prelude hiding (not)
+
+import GHC.Generics
 
 ----------------------------------------------------------------------------------------------------
 -- Conditional
@@ -12,46 +18,24 @@ class Conditional a where
     -- | Join two values or returns two variants for undetermined condition in conditional statement.
     cond :: Formula -> a -> a -> a
 
+    -- Default implementation when the type is generic
+    default cond :: (Generic a, GConditional (Rep a)) => Formula -> a -> a -> a
+    cond f x y = to (gcond f (from x) (from y))
+
 instance Conditional Formula where
     cond f1 f2 f3 = (f1 /\ f2) \/ (not f1 /\ f3)
 
 instance Conditional b => Conditional (a -> b) where
     cond c f1 f2 x = cond c (f1 x) (f2 x)
 
-instance (Conditional a) => Conditional [a] where
-    cond c l1 l2 = if length l1 == length l2
-                           then zipWith (cond c) l1 l2
-                           else case solve c of
-                                  Just True  -> l1
-                                  Just False -> l2
-                                  Nothing    -> error "cond cannot be applied to lists of different sizes with undetermined condition"
 
-instance Conditional () where
-    cond c _ _ = ()
-
-instance (Conditional a, Conditional b) => Conditional (a,b) where
-    cond c (a1,b1) (a2,b2) = (cond c a1 a2, cond c b1 b2)
-
-instance (Conditional a, Conditional b, Conditional c) => Conditional (a,b,c) where
-    cond c (a1,b1,c1) (a2,b2,c2) = (cond c a1 a2, cond c b1 b2, cond c c1 c2)
-
-instance (Conditional a, Conditional b, Conditional c, Conditional d) => Conditional (a,b,c,d) where
-    cond c (a1,b1,c1,d1) (a2,b2,c2,d2) = (cond c a1 a2, cond c b1 b2, cond c c1 c2, cond c d1 d2)
-
-instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e) => Conditional (a,b,c,d,e) where
-    cond c (a1,b1,c1,d1,e1) (a2,b2,c2,d2,e2) = (cond c a1 a2, cond c b1 b2, cond c c1 c2, cond c d1 d2, cond c e1 e2)
-
-instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e, Conditional f) => Conditional (a,b,c,d,e,f) where
-    cond c (a1,b1,c1,d1,e1,f1) (a2,b2,c2,d2,e2,f2) = (cond c a1 a2, cond c b1 b2, cond c c1 c2,
-                                                      cond c d1 d2, cond c e1 e2, cond c f1 f2)
-
-instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e, Conditional f, Conditional g) => Conditional (a,b,c,d,e,f,g) where
-    cond c (a1,b1,c1,d1,e1,f1,g1) (a2,b2,c2,d2,e2,f2,g2) = (cond c a1 a2, cond c b1 b2, cond c c1 c2, cond c d1 d2,
-                                                            cond c e1 e2, cond c f1 f2, cond c g1 g2)
-
-instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e, Conditional f, Conditional g, Conditional h) => Conditional (a,b,c,d,e,f,g,h) where
-    cond c (a1,b1,c1,d1,e1,f1,g1,h1) (a2,b2,c2,d2,e2,f2,g2,h2) = (cond c a1 a2, cond c b1 b2, cond c c1 c2, cond c d1 d2,
-                                                                  cond c e1 e2, cond c f1 f2, cond c g1 g2, cond c h1 h2)
+instance Conditional ()
+instance (Conditional a, Conditional b) => Conditional (a,b)
+instance (Conditional a, Conditional b, Conditional c) => Conditional (a,b,c)
+instance (Conditional a, Conditional b, Conditional c, Conditional d) => Conditional (a,b,c,d)
+instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e) => Conditional (a,b,c,d,e)
+instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e, Conditional f) => Conditional (a,b,c,d,e,f)
+instance (Conditional a, Conditional b, Conditional c, Conditional d, Conditional e, Conditional f, Conditional g) => Conditional (a,b,c,d,e,f,g)
 
 ----------------------------------------------------------------------------------------------------
 -- if then else with formula solving
@@ -64,3 +48,30 @@ ite c x1 x2
     | f == false = x2
     | otherwise  = cond f x1 x2
   where f = simplifyFormula c
+
+----------------------------------------------------------------------------------------------------
+-- Generics
+----------------------------------------------------------------------------------------------------
+
+class GConditional f where
+    gcond :: Formula -> f a -> f a -> f a
+
+-- The generic instances for the void and unit types are trivial
+instance GConditional V1 where gcond _ _ = id
+instance GConditional U1 where gcond _ U1 U1 = U1
+
+-- The instances for K1 and M1 are clear as well
+instance Conditional c => GConditional (K1 i c)
+    where gcond f (K1 x) (K1 y) = K1 (cond f x y)
+instance GConditional f => GConditional (M1 i c f)
+    where gcond f (M1 x) (M1 y) = M1 (gcond f x y)
+
+-- Then the instance for products is as we expect
+instance (GConditional f, GConditional g) => GConditional (f :*: g)
+    where gcond f (a1 :*: b1) (a2 :*: b2) = gcond f a1 a2 :*: gcond f b1 b2
+
+-- There is *no* instance for sums, because in general we might not be able to
+-- decide the formula and then cannot combine a Left and Right value.
+
+-- This also means that any list instance is an "unsafe" instance which may
+-- crash. There used to be an instance for lists, it has been removed now.

--- a/src/Nominal/Conditional.hs
+++ b/src/Nominal/Conditional.hs
@@ -14,6 +14,7 @@ import GHC.Generics
 ----------------------------------------------------------------------------------------------------
 
 -- | Class of types implementing conditional statements.
+-- This class can be derived using generics.
 class Conditional a where
     -- | Join two values or returns two variants for undetermined condition in conditional statement.
     cond :: Formula -> a -> a -> a

--- a/src/Nominal/Contextual.hs
+++ b/src/Nominal/Contextual.hs
@@ -17,6 +17,7 @@ import GHC.Generics
 ----------------------------------------------------------------------------------------------------
 
 -- | Class of types of expressions to evaluating with a given context.
+-- This class can be derived using generics.
 class Contextual a where
     -- | Evaluates an expression in the context of a given formula.
     when :: Formula -> a -> a

--- a/src/Nominal/Contextual.hs
+++ b/src/Nominal/Contextual.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Nominal.Contextual where
 
 import Data.Map (Map, assocs, fromList)
@@ -6,6 +10,7 @@ import Nominal.Formula
 import Nominal.Formula.Operators
 import Nominal.Variable (Variable)
 import Prelude hiding (map, not)
+import GHC.Generics
 
 ----------------------------------------------------------------------------------------------------
 -- Contextual
@@ -15,7 +20,10 @@ import Prelude hiding (map, not)
 class Contextual a where
     -- | Evaluates an expression in the context of a given formula.
     when :: Formula -> a -> a
-    when = const id
+
+    -- Default implementation when the type is generic
+    default when :: (Generic a, GContextual (Rep a)) => Formula -> a -> a
+    when f = to . gwhen f . from
 
 -- | Evaluates an expression in the context of a 'true' formula. In practice all formulas in expressions are solved.
 --
@@ -30,7 +38,9 @@ simplify = when true
 instance Contextual b => Contextual (a -> b) where
     when ctx f = when ctx . f
 
-instance Contextual Variable
+-- We do not do anything on variables. We could rename variables given the
+-- context... But currently we don't
+instance Contextual Variable where when = const id
 
 instance Contextual Formula where
     when ctx f
@@ -39,56 +49,53 @@ instance Contextual Formula where
         | isTrue (ctx ==> not f) = false
         | otherwise = simplifyFormula $ mapFormula (when ctx) f
 
-instance Contextual Bool
-
-instance Contextual Char
-
-instance Contextual Double
-
-instance Contextual Float
-
-instance Contextual Int
-
-instance Contextual Integer
-
-instance Contextual Ordering
-
-instance Contextual a => Contextual [a] where
-    when ctx = fmap (when ctx)
+-- Trivial instances, elements cannot be simplified in some context
+instance Contextual Bool where when = const id
+instance Contextual Char where when = const id
+instance Contextual Double where when = const id
+instance Contextual Float where when = const id
+instance Contextual Int where when = const id
+instance Contextual Integer where when = const id
+instance Contextual Ordering where when = const id
 
 instance Contextual ()
+instance (Contextual a, Contextual b) => Contextual (a,b)
+instance (Contextual a, Contextual b, Contextual c) => Contextual (a,b,c)
+instance (Contextual a, Contextual b, Contextual c, Contextual d) => Contextual (a,b,c,d)
+instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e) => Contextual (a,b,c,d,e)
+instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e, Contextual f) => Contextual (a,b,c,d,e,f)
+instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e, Contextual f, Contextual g) => Contextual (a,b,c,d,e,f,g)
 
-instance (Contextual a, Contextual b) => Contextual (a,b) where
-    when ctx (a,b) = (when ctx a, when ctx b)
-
-instance (Contextual a, Contextual b, Contextual c) => Contextual (a,b,c) where
-    when ctx (a,b,c) = (when ctx a, when ctx b, when ctx c)
-
-instance (Contextual a, Contextual b, Contextual c, Contextual d) => Contextual (a,b,c,d) where
-    when ctx (a,b,c,d) = (when ctx a, when ctx b, when ctx c, when ctx d)
-
-instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e) => Contextual (a,b,c,d,e) where
-    when ctx (a,b,c,d,e) = (when ctx a, when ctx b, when ctx c, when ctx d, when ctx e)
-
-instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e, Contextual f) => Contextual (a,b,c,d,e,f) where
-    when ctx (a,b,c,d,e,f) = (when ctx a, when ctx b, when ctx c, when ctx d, when ctx e, when ctx f)
-
-instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e, Contextual f, Contextual g) => Contextual (a,b,c,d,e,f,g) where
-    when ctx (a,b,c,d,e,f,g) = (when ctx a, when ctx b, when ctx c, when ctx d, when ctx e, when ctx f, when ctx g)
-
-instance (Contextual a, Contextual b, Contextual c, Contextual d, Contextual e, Contextual f, Contextual g, Contextual h) => Contextual (a,b,c,d,e,f,g,h) where
-    when ctx (a,b,c,d,e,f,g,h) = (when ctx a, when ctx b, when ctx c, when ctx d, when ctx e, when ctx f, when ctx g, when ctx h)
-
-instance Contextual a => Contextual (Maybe a) where
-    when ctx = fmap (when ctx)
-
-instance (Contextual a, Contextual b) => Contextual (Either a b) where
-    when ctx (Left v) = Left $ when ctx v
-    when ctx (Right v) = Right $ when ctx v
+instance Contextual a => Contextual [a]
+instance Contextual a => Contextual (Maybe a)
+instance (Contextual a, Contextual b) => Contextual (Either a b)
 
 instance (Contextual a, Ord a) => Contextual (Set a) where
     when ctx = map (when ctx)
 
-instance (Contextual k, Contextual v, Ord k, Ord v) => Contextual (Map k v) where
+instance (Contextual k, Contextual v, Ord k) => Contextual (Map k v) where
     when ctx = fromList . when ctx . assocs
 
+----------------------------------------------------------------------------------------------------
+-- Generics
+----------------------------------------------------------------------------------------------------
+
+class GContextual f where
+    gwhen :: Formula -> f a -> f a
+
+-- As always, the void and unit instances are easy
+instance GContextual V1 where gwhen f = id
+instance GContextual U1 where gwhen f = id
+
+-- Then the constant and constructor case
+instance Contextual c => GContextual (K1 i c) where
+    gwhen f = K1 . when f . unK1
+instance GContextual f => GContextual (M1 i c f) where
+    gwhen f = M1 . gwhen f . unM1
+
+-- Then the "interesting" cases: sum, product and composition
+instance (GContextual f, GContextual g) => GContextual (f :+: g) where
+    gwhen f (L1 x) = L1 (gwhen f x)
+    gwhen f (R1 x) = R1 (gwhen f x)
+instance (GContextual f, GContextual g) => GContextual (f :*: g) where
+    gwhen f (x :*: y) = gwhen f x :*: gwhen f y

--- a/src/Nominal/Formula/Definition.hs
+++ b/src/Nominal/Formula/Definition.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Nominal.Formula.Definition where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import Data.List.Utils (join)
 import Data.Set (Set, elems, fromList)
 import Nominal.Atoms.Signature (Relation)
@@ -22,7 +19,7 @@ data FormulaStructure
     | Constraint Relation Variable Variable
     | And (Set Formula)
     | Or (Set Formula)
-    | Not Formula deriving (Eq, Ord, Generic, NFData)
+    | Not Formula deriving (Eq, Ord)
 
 ----------------------------------------------------------------------------------------------------
 -- Show
@@ -89,7 +86,6 @@ instance Read FormulaStructure where
 
 -- | First order formula with free variables and relations between variables.
 data Formula = Formula {isSimplified :: Bool, formula :: FormulaStructure}
-  deriving (Generic, NFData)
 
 instance Eq Formula where
     (Formula _ f1) == (Formula _ f2) = f1 == f2

--- a/src/Nominal/Graph.hs
+++ b/src/Nominal/Graph.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Nominal.Graph where
 
 import Data.Tuple (swap)
@@ -11,25 +12,15 @@ import Nominal.Set
 import Nominal.Type
 import Nominal.Variants hiding (fromList, map)
 import Prelude hiding (filter, map, not, or, sum)
+import GHC.Generics (Generic)
 
 ----------------------------------------------------------------------------------------------------
 -- Graph
 ----------------------------------------------------------------------------------------------------
 
 -- | A directed graph with vertices of type __a__ and set of pairs representing edges.
-data Graph a = Graph {vertices :: Set a, edges :: Set (a,a)} deriving (Eq, Ord, Show, Read)
-
-instance NominalType a => Conditional (Graph a) where
-    cond c (Graph vs1 es1) (Graph vs2 es2) = Graph (cond c vs1 vs2) (cond c es1 es2)
-
-instance (Contextual a, Ord a) => Contextual (Graph a) where
-    when ctx (Graph vs es) = Graph (when ctx vs) (when ctx es)
-
-instance NominalType a => BareNominalType (Graph a) where
-    eq (Graph vs1 es1) (Graph vs2 es2) = eq vs1 vs2 /\ eq es1 es2
-    variants = variant
-    mapVariables f (Graph vs es) = Graph (mapVariables f vs) (mapVariables f es)
-    foldVariables f acc (Graph vs es) = foldVariables f (foldVariables f acc vs) es
+data Graph a = Graph {vertices :: Set a, edges :: Set (a,a)}
+  deriving (Eq, Ord, Show, Read, Generic, BareNominalType, Conditional, Contextual)
 
 ----------------------------------------------------------------------------------------------------
 -- Graph constructors

--- a/src/Nominal/Graph.hs
+++ b/src/Nominal/Graph.hs
@@ -20,7 +20,7 @@ import GHC.Generics (Generic)
 
 -- | A directed graph with vertices of type __a__ and set of pairs representing edges.
 data Graph a = Graph {vertices :: Set a, edges :: Set (a,a)}
-  deriving (Eq, Ord, Show, Read, Generic, BareNominalType, Conditional, Contextual)
+  deriving (Eq, Ord, Show, Read, Generic, NominalType, Conditional, Contextual)
 
 ----------------------------------------------------------------------------------------------------
 -- Graph constructors

--- a/src/Nominal/Set.hs
+++ b/src/Nominal/Set.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Nominal.Set (
 Set,
 -- ** Construction
@@ -90,7 +89,6 @@ isClosed,
 isCompact) where
 
 import Control.Arrow ((***), first)
-import Control.DeepSeq (NFData)
 import Data.IORef (IORef, readIORef, newIORef, writeIORef)
 import qualified Data.List as List ((\\), partition)
 import Data.List.Utils (join)
@@ -99,7 +97,6 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Word (Word)
-import GHC.Generics (Generic)
 import GHC.Read (expectP)
 import Nominal.Atoms
 import Nominal.Atoms.Logic (exclusiveConditions)
@@ -209,7 +206,7 @@ applyWithIdentifiers f (v, cond) =
 ----------------------------------------------------------------------------------------------------
 
 -- | The set of elements, can be infinite.
-newtype Set a = Set {setElements :: Map a SetElementCondition} deriving (Eq, Ord, Generic, NFData)
+newtype Set a = Set {setElements :: Map a SetElementCondition} deriving (Eq, Ord)
 
 instance Show a => Show (Set a) where
     show s = "{" ++ join ", " (fmap showSetElement (Map.assocs $ setElements s)) ++ "}"

--- a/src/Nominal/Set.hs
+++ b/src/Nominal/Set.hs
@@ -108,7 +108,7 @@ import Nominal.Formula.Constructors (constraint)
 import Nominal.Formula.Operators (getConstraintsFromFormula, getEquationsFromFormula)
 import Nominal.Maybe
 import qualified Nominal.Text.Symbols as Symbols
-import Nominal.Type (FoldVarFun, MapVarFun, BareNominalType(..), NominalType(..), Scope(..), collectWith, freeVariables, getAllVariables, mapVariablesIf, neq, replaceVariables)
+import Nominal.Type (FoldVarFun, MapVarFun, NominalType(..), Scope(..), collectWith, freeVariables, getAllVariables, mapVariablesIf, neq, replaceVariables)
 import qualified Nominal.Util.InsertionSet as ISet
 import Nominal.Util.UnionFind (representatives)
 import Nominal.Util.Read (optional, readSepBy, skipSpaces, spaces, string)
@@ -273,7 +273,7 @@ foldSetVariables :: NominalType a => FoldVarFun b -> b -> (a, SetElementConditio
 foldSetVariables (All, f) acc se = foldVariables (All, f) acc se
 foldSetVariables (Free, f) acc (v, (vs, c)) = foldVariables (Free, foldWithout vs f) acc (v, (vs, c))
 
-instance NominalType a => BareNominalType (Set a) where
+instance NominalType a => NominalType (Set a) where
     eq s1 s2 = isSubsetOf s1 s2 /\ isSubsetOf s2 s1
     variants = variant
     mapVariables f (Set es) = Set $ Map.fromListWith sumCondition $ fmap (mapSetVariables f) (Map.assocs es)
@@ -283,13 +283,13 @@ instance NominalType a => BareNominalType (Set a) where
 -- Similar instances
 ----------------------------------------------------------------------------------------------------
 
-instance NominalType a => BareNominalType (Set.Set a) where
+instance NominalType a => NominalType (Set.Set a) where
     eq s1 s2 = eq (fromList $ Set.elems s1) (fromList $ Set.elems s2)
     variants = variant
     mapVariables f = Set.map (mapVariables f)
     foldVariables f acc = foldVariables f acc . Set.elems
 
-instance (NominalType k, NominalType a) => BareNominalType (Map k a) where
+instance (NominalType k, NominalType a) => NominalType (Map k a) where
     eq m1 m2 = eq (fromList $ Map.assocs m1) (fromList $ Map.assocs m2)
     variants = variant
     mapVariables f = Map.fromList . mapVariables f . Map.assocs

--- a/src/Nominal/Type.hs
+++ b/src/Nominal/Type.hs
@@ -1,17 +1,6 @@
 {-# LANGUAGE DefaultSignatures, FlexibleContexts, CPP, TypeOperators #-}
 
-module Nominal.Type (
-Scope(..),
-MapVarFun,
-FoldVarFun,
-NominalType(..),
-neq,
-collectWith,
-getAllVariables,
-freeVariables,
-mapVariablesIf,
-replaceVariables
-)where
+module Nominal.Type where
 
 import Data.Map (Map, findWithDefault)
 import Data.Set (Set, empty, insert)
@@ -39,7 +28,15 @@ type MapVarFun = (Scope, Variable -> Variable)
 type FoldVarFun b = (Scope, Variable -> b -> b)
 
 -- | Basic type in 'NLambda' required by most of functions in the module.
--- | The Ord instance is used for efficiency.
+-- The Ord instance is used for efficiency.
+-- By using generics, one can derive instances of this class for custom
+-- data types, like this:
+--
+-- > {-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+-- > import GHC.Generics (Generic)
+-- >
+-- > data Foo = Foo1 Atom [Atom] | Foo2 (Set Atom)
+-- >   deriving (Eq, Ord, Generic, NominalType)
 class Ord a => NominalType a where
     -- | Checks equivalence of two given elements.
     eq :: a -> a -> Formula

--- a/src/Nominal/Type.hs
+++ b/src/Nominal/Type.hs
@@ -1,6 +1,17 @@
-{-# LANGUAGE ConstraintKinds, DefaultSignatures, FlexibleContexts, CPP, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, FlexibleContexts, CPP, TypeOperators #-}
 
-module Nominal.Type where
+module Nominal.Type (
+Scope(..),
+MapVarFun,
+FoldVarFun,
+NominalType(..),
+neq,
+collectWith,
+getAllVariables,
+freeVariables,
+mapVariablesIf,
+replaceVariables
+)where
 
 import Data.Map (Map, findWithDefault)
 import Data.Set (Set, empty, insert)

--- a/src/Nominal/Variable.hs
+++ b/src/Nominal/Variable.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Nominal.Variable (
 Identifier,
 Variable,
@@ -17,8 +16,6 @@ changeIterationLevel,
 toParts,
 fromParts) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import GHC.Unicode (isAsciiLower)
 import Data.Map (Map, findWithDefault)
 import Data.Word (Word)
@@ -36,7 +33,7 @@ import Text.Read.Lex (readIntP)
 type Identifier = Word
 
 -- | Free variable in a 'Nominal.Formula' or iteration variable in a 'Nominal.Set' or constant.
-data Variable = Var String | IterationVariable Int Int (Maybe Identifier) | ConstantVar Constant deriving (Eq, Ord, Generic, NFData)
+data Variable = Var String | IterationVariable Int Int (Maybe Identifier) | ConstantVar Constant deriving (Eq, Ord)
 
 ----------------------------------------------------------------------------------------------------
 -- Constant

--- a/src/Nominal/Variants.hs
+++ b/src/Nominal/Variants.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 module Nominal.Variants (
 Variants,
 variant,
@@ -14,8 +13,6 @@ prodWithMono,
 readVariant,
 variantsRelation) where
 
-import Control.DeepSeq (NFData)
-import GHC.Generics (Generic)
 import Control.Applicative ((<*>))
 import Data.Functor ((<$>))
 import Data.List.Utils (join)
@@ -35,7 +32,7 @@ import Text.Read (ReadPrec, (<++), parens, prec, readPrec, step)
 
 -- | Storing values under various conditions, which could not be solved as 'true' or 'false'.
 -- Is often the result of 'ite' or 'iteV' functions.
-newtype Variants a = Variants (Map a Formula) deriving (Eq, Ord, Generic, NFData)
+newtype Variants a = Variants (Map a Formula) deriving (Eq, Ord)
 
 -- | Creates a single variant.
 variant :: a -> Variants a

--- a/src/Nominal/Variants.hs
+++ b/src/Nominal/Variants.hs
@@ -7,9 +7,7 @@ toList,
 fromList,
 satisfying,
 Nominal.Variants.map,
-mapWithMono,
 prod,
-prodWithMono,
 readVariant,
 variantsRelation) where
 
@@ -92,10 +90,6 @@ satisfying f (Variants vs) = or $ Map.elems $ Map.filterWithKey (const . f) vs
 map :: Ord b => (a -> b) -> Variants a -> Variants b
 map f (Variants vs) = Variants (Map.mapKeysWith (\/) f vs)
 
--- unchecked! monotonic map
-mapWithMono :: (a -> b) -> Variants a -> Variants b
-mapWithMono f (Variants vs) = Variants (Map.mapKeysMonotonic f vs)
-
 -- Take the 'product' in a way.
 prod :: Variants a -> Variants b -> Variants (a, b)
 prod (Variants as) (Variants bs) = Variants . fromList $ merge <$> toList as <*> toList bs
@@ -108,10 +102,6 @@ prod (Variants as) (Variants bs) = Variants . fromList $ merge <$> toList as <*>
         -- we use this to avoid a constraint. Note that the pairing is
         -- monotone, so it is valid. (Depends on the order of <*>)
         fromList = Map.fromDistinctAscList
-
--- unchecked!
-prodWithMono :: (a -> b -> c) -> Variants a -> Variants b -> Variants c
-prodWithMono f as bs = mapWithMono (uncurry f) $ prod as bs
 
 -- | Returns value of a single variant.
 fromVariant :: Variants a -> a


### PR DESCRIPTION
I added generic instances of `Conditional` and `Contextual`.
This allows for the following (contrived example) to be written:
```
{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}

module Main where
import NLambda
import GHC.Generics (Generic)

data Foo a = Foo { ls :: (Formula, a), ss :: Set a}
  deriving (Eq, Ord, Show, Generic, BareNominalType, Conditional, Contextual)

main = do
  let a = atom "a"
  let b = atom "b"
  print . simplify $ ite (a `eq` b)
                         (Foo {ls = (true, false), ss = fromList [a `eq` b]})
                         (Foo {ls = (true, true), ss = fromList [a `neq` b]})

```
this correctly prints `Foo {ls = (true,a ≠ b), ss = {true}}`. So we see that things like `ite` and `simplify` work inside the structures nicely.

Along the way, I removed some `Generic` and `NFData` instances, as I think they didn't belong in those places.

And the instances for `Automaton` and `Graph` have been replaced by the generic instances. This cleans up the code a bit (since the instances were obvious anyways).

I am putting this in a pull request / branch, so that we have a change to tweak it a bit before putting it on master.